### PR TITLE
fix(chat): prevent chat disconnections by ensuring friend lookup resolves

### DIFF
--- a/server/src/redisClient.js
+++ b/server/src/redisClient.js
@@ -47,6 +47,10 @@ export const getRandom = async (user) => {
 	if (existing) return existing;
 
 	while (Date.now() - start < TIMEOUT_MS) {
+
+		const existing = await redis.hGet("friends", user);
+		if (existing) return existing;
+
 		const friend = await redis.sRandMember("activeUsers");
 		if (!friend || friend === user) {
 			await new Promise(r => setTimeout(r, INTERVAL_MS));


### PR DESCRIPTION
This PR fixes the chat disconnection issue caused by users not being matched properly when joining the chat.  

## Changes Made
- Added an additional `redis.hGet("friends", user)` check **inside the while loop**.  
- Ensures that if a friend already exists, the function returns immediately instead of waiting unnecessarily.  
- Reduces chances of unresolved promises that were causing the chat to disconnect.


